### PR TITLE
fix: bump required Ruby version to 3.0+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ["3.0", "3.1"]
+        ruby-version: ["3.0", "3.1", "3.2", "3.3"]
 
     steps:
       - uses: actions/checkout@v2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    daily-ruby (1.0.3)
+    daily-ruby (1.0.4)
       faraday (>= 1.0.1, < 3.0)
       faraday-multipart
       marcel

--- a/daily-ruby.gemspec
+++ b/daily-ruby.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.summary     = "The official Daily API Ruby client"
   s.description = "The official Daily API Ruby client for Daily's REST API"
   s.license     = "MIT"
-  s.required_ruby_version = ">= 2.7"
+  s.required_ruby_version = ">= 3.0"
   s.metadata    = {}
 
   s.add_runtime_dependency 'faraday', '>= 1.0.1', '< 3.0'

--- a/lib/daily-ruby/version.rb
+++ b/lib/daily-ruby/version.rb
@@ -11,5 +11,5 @@ Generator version: 7.8.0
 =end
 
 module Daily
-  VERSION = '1.0.3'
+  VERSION = '1.0.4'
 end


### PR DESCRIPTION
## Summary
- Bumps `required_ruby_version` from `>= 2.7` to `>= 3.0` in the gemspec to unblock Dependabot from resolving faraday >= 2.9.0 (fixes SSRF vulnerability in [Dependabot alert #9](https://github.com/daily-co/daily-ruby/security/dependabot/9))
- Adds Ruby 3.2 and 3.3 to the CI test matrix (3.0 and 3.1 are EOL)

## Test plan
- [x] `bundle install` resolves successfully
- [x] All 750 RSpec tests pass
- [x] CI passes on Ruby 3.0, 3.1, 3.2, and 3.3
- [x] Dependabot can now resolve the faraday SSRF vulnerability

🤖 Generated with [Claude Code](https://claude.com/claude-code)